### PR TITLE
Reorder D7S flag before SI and PGA

### DIFF
--- a/4GmainRev2Codex.ino
+++ b/4GmainRev2Codex.ino
@@ -255,7 +255,7 @@ static void collectAndSendSamples(bool earthquakeTriggered) {
   // pm1, pm2_5, pm4, pm10, voc_index, nox_index,
   // sen55_fan_err, sen55_speed_warn, sen55_laser_err, sen55_rht_err, sen55_gas_err, sen55_cleaning,
   // bme_temp_c_x100, bme_rh_x100, bme_pressure_pa_x100, bme_gas_ohm_x100,
-  // d7s_si_mps, d7s_pga_mps2, d7s_eq_bit,
+  // d7s_eq_bit, d7s_si_mps, d7s_pga_mps2,
   // bat_mV_x100, bat_pct,
   // latitude, longitude
 
@@ -268,7 +268,7 @@ static void collectAndSendSamples(bool earthquakeTriggered) {
     String((sen55_status_b>>0)&1), String((sen55_status_b>>1)&1), String((sen55_status_b>>2)&1),
     String((sen55_status_b>>3)&1), String((sen55_status_b>>4)&1), String((sen55_status_b>>5)&1),
     String(BME680temp), String(BME680humidity), String(BME680pressure), String(BME680gas),
-    String(d7s_si_out, 3), String(d7s_pga_out, 3), String(d7s_eq_out),
+    String(d7s_eq_out), String(d7s_si_out, 3), String(d7s_pga_out, 3),
     String(batV_x100), String(batPct),
     String(latitude), String(longitude)
   );
@@ -283,7 +283,7 @@ static void collectAndSendSamples(bool earthquakeTriggered) {
       String((sen55_status_b>>0)&1), String((sen55_status_b>>1)&1), String((sen55_status_b>>2)&1),
       String((sen55_status_b>>3)&1), String((sen55_status_b>>4)&1), String((sen55_status_b>>5)&1),
       String(BME680temp), String(BME680humidity), String(BME680pressure), String(BME680gas),
-      String(d7s_si_out, 3), String(d7s_pga_out, 3), String(d7s_eq_out),
+      String(d7s_eq_out), String(d7s_si_out, 3), String(d7s_pga_out, 3),
       String(batV_x100), String(batPct),
       String(latitude), String(longitude)
     );


### PR DESCRIPTION
## Summary
- update the D7S data column ordering comment to reflect the desired layout
- pass the earthquake flag before the SI and PGA values when writing to the SD card
- match the same D7S argument order when sending data to Google Sheets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d10c36d3788323b3752260a191194f