### PR TITLE
Scale D7S samples before logging and upload

### DIFF
--- a/4GmainRev2Codex.ino
+++ b/4GmainRev2Codex.ino
@@ -224,7 +224,12 @@ static void collectAndSendSamples(bool earthquakeTriggered) {
     }
   }
 
-  Serial.printf("D7S SI=%.3f m/s  PGA=%.3f m/s^2  EQ=%d\n", d7s_si_out, d7s_pga_out, d7s_eq_out);
+  int d7s_si_x100  = lroundf(d7s_si_out  * 100.0f);
+  int d7s_pga_x100 = lroundf(d7s_pga_out * 100.0f);
+  String d7sSiStr  = String(d7s_si_x100);
+  String d7sPgaStr = String(d7s_pga_x100);
+  Serial.printf("D7S SI=%.3f m/s (x100=%d)  PGA=%.3f m/s^2 (x100=%d)  EQ=%d\n",
+                d7s_si_out, d7s_si_x100, d7s_pga_out, d7s_pga_x100, d7s_eq_out);
 
   // --- Batteria ---
   float vbat = readBatteryVoltage();
@@ -255,7 +260,7 @@ static void collectAndSendSamples(bool earthquakeTriggered) {
   // pm1, pm2_5, pm4, pm10, voc_index, nox_index,
   // sen55_fan_err, sen55_speed_warn, sen55_laser_err, sen55_rht_err, sen55_gas_err, sen55_cleaning,
   // bme_temp_c_x100, bme_rh_x100, bme_pressure_pa_x100, bme_gas_ohm_x100,
-  // d7s_eq_bit, d7s_si_mps, d7s_pga_mps2,
+  // d7s_eq_bit, d7s_si_mps_x100, d7s_pga_mps2_x100,
   // bat_mV_x100, bat_pct,
   // latitude, longitude
 
@@ -268,7 +273,7 @@ static void collectAndSendSamples(bool earthquakeTriggered) {
     String((sen55_status_b>>0)&1), String((sen55_status_b>>1)&1), String((sen55_status_b>>2)&1),
     String((sen55_status_b>>3)&1), String((sen55_status_b>>4)&1), String((sen55_status_b>>5)&1),
     String(BME680temp), String(BME680humidity), String(BME680pressure), String(BME680gas),
-    String(d7s_eq_out), String(d7s_si_out, 3), String(d7s_pga_out, 3),
+    String(d7s_eq_out), d7sSiStr, d7sPgaStr,
     String(batV_x100), String(batPct),
     String(latitude), String(longitude)
   );
@@ -283,7 +288,7 @@ static void collectAndSendSamples(bool earthquakeTriggered) {
       String((sen55_status_b>>0)&1), String((sen55_status_b>>1)&1), String((sen55_status_b>>2)&1),
       String((sen55_status_b>>3)&1), String((sen55_status_b>>4)&1), String((sen55_status_b>>5)&1),
       String(BME680temp), String(BME680humidity), String(BME680pressure), String(BME680gas),
-      String(d7s_eq_out), String(d7s_si_out, 3), String(d7s_pga_out, 3),
+      String(d7s_eq_out), d7sSiStr, d7sPgaStr,
       String(batV_x100), String(batPct),
       String(latitude), String(longitude)
     );


### PR DESCRIPTION
## Summary
- scale the D7S SI and PGA values by 100 before logging and uploading
- send the scaled D7S strings to both SD and Google Sheets outputs and clarify column docs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d10e1f69b083239821f10ec9c43b34