### PR TITLE
Increase D7S stale timeout to 40s

### DIFF
--- a/4GmainRev2Codex.ino
+++ b/4GmainRev2Codex.ino
@@ -36,7 +36,7 @@ String longitude;
 // ======= D7S (Grove) =======
 #include <D7S.h>
 // Logica anti-stallo (come nel tuo esempio)
-static const uint32_t D7S_STALE_TIME_MS = 3000;
+static const uint32_t D7S_STALE_TIME_MS = 40000;
 static const float    D7S_EPS_SI        = 0.002f;  // m/s
 static const float    D7S_EPS_PGA       = 0.020f;  // m/s^2
 // Stato anti-stallo


### PR DESCRIPTION
## Summary
- update the D7S anti-stall stale timeout constant to 40 seconds to prolong event persistence

## Testing
- not run (arduino-cli not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d1169f10b48323b7a4cbdb81b560d6